### PR TITLE
Do not verify genesis block

### DIFF
--- a/src/light.js
+++ b/src/light.js
@@ -208,6 +208,11 @@ const startLightClient = async _ => {
 
         }
 
+        // Because genesis block doesn't have any commitment in header
+        if (BigInt(header.number) < 1n) {
+            return
+        }
+
         const start = new Date().getTime()
         console.log(`🛠   Verifying block : ${header.number}`)
 


### PR DESCRIPTION
As genesis block does not have any commitment, light client used to panic.