### PR TITLE
HTTP GET API for block confidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ curl -s -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","method":"get_b
   "id": 1,
   "result": {
     "number": 223,
-    "confidence": "99.99223 %"
+    "confidence": 99.90234375
   }
 }
 ```
@@ -88,7 +88,7 @@ curl -s -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","method":"get_b
   "id": 1,
   "result": {
     "number": true,
-    "confidence": "0 %",
+    "confidence": 0,
     "error": "Block number must be number/ string"
   }
 }

--- a/src/rpc.js
+++ b/src/rpc.js
@@ -24,7 +24,7 @@ server.addMethod('get_blockConfidence', async ({ number }) => {
     async function wrapperOnConfidenceFetcher(number) {
 
         if(BigInt(number) < 1n) {
-            return '0 %'
+            return 0
         }
 
         if (state.alreadyVerified(number)) {
@@ -32,12 +32,12 @@ server.addMethod('get_blockConfidence', async ({ number }) => {
         }
 
         if(state.latestBlock < BigInt(number)) {
-            return '0 %'
+            return 0
         }
 
         const resp = await lc.processBlockByNumber(BigInt(number))
         if (resp.status != 1) {
-            return '0 %'
+            return 0
         }
 
         return state.getConfidence(number)
@@ -56,7 +56,7 @@ server.addMethod('get_blockConfidence', async ({ number }) => {
             } :
             {
                 number,
-                confidence: '0 %',
+                confidence: 0,
                 error: 'Block number must be number/ string'
             }
 })

--- a/src/state.js
+++ b/src/state.js
@@ -23,7 +23,7 @@ class BlockConfidence {
     }
 
     getConfidence(number) {
-        return `${(1 - (1 / Math.pow(2, this.blocks[number] || 0))) * 100} %`
+        return (1 - (1 / Math.pow(2, this.blocks[number] || 0))) * 100
     }
 
     done() {


### PR DESCRIPTION
## What's new ?

HTTP GET API added for sake of simplicity in smart contract based light client work flow ( primarily based on ChainLink Oracles ).

Few fixes added for handling bad block number as query argument.
